### PR TITLE
fix: 거래목록 생성(입금, 출금)의 amount 타입 변경 및 repository 의 기능 이전

### DIFF
--- a/src/accounts/entities/account.entity.ts
+++ b/src/accounts/entities/account.entity.ts
@@ -11,11 +11,6 @@ export class Account extends CoreEntity {
   @Column({ default: 0 })
   money: number;
 
-  @OneToMany((_type) => Transaction, (transaction) => transaction.account, {
-    eager: true,
-  })
-  transactions: Transaction[];
-
   @ManyToOne((_type) => User, (user) => user.accounts, {
     eager: false,
     onDelete: 'CASCADE',

--- a/src/transaction/dto/create-transaction.dto.ts
+++ b/src/transaction/dto/create-transaction.dto.ts
@@ -1,16 +1,11 @@
-import { IsInt, IsString, Min } from 'class-validator';
+import { IsString } from 'class-validator';
 
 export class CreateTransactionDto {
-
   @IsString()
   acc_num: string;
 
   @IsString()
-  acc_num: string;
-
-  @IsInt()
-  @Min(0)
-  amount: number;
+  amount: string;
 
   @IsString()
   comments: string;

--- a/src/transaction/transaction.repository.ts
+++ b/src/transaction/transaction.repository.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { EntityRepository, Repository } from 'typeorm';
 import * as moment from 'moment-timezone';
 import { Transaction } from './entities/transaction.entity';
@@ -81,11 +81,5 @@ export class TransactionRepository extends Repository<Transaction> {
       .getMany();
     // * select 로 특정 컬럼만 응답에 포함합니다. [거래일시, 거래금액, 잔액, 거래종류, 적요]
     return transaction;
-  }
-  //계좌의 잔액과 출금액을 비교해서 계좌의 잔액이 더 커야함
-  compareMoneyAndAmount(money: number, amount: number) {
-    if (money < amount) {
-      throw new BadRequestException('계좌의 잔액이 부족합니다.');
-    }
   }
 }


### PR DESCRIPTION
## 작업 분류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트

## 작업 개요
- 입금, 출금 때 사용하는 CreateTransactionDto 에서 amount 의 타입을 변경

## 상세 내용
- 처음 요청을 받을 때는 모든 값들이 문자열인데, amount 를 숫자 타입으로 유효성 검증을 하면서 생긴 문제입니다.
- dto 에서 amount 타입을 문자열로 변환하고, 서비스에서 그 값을 숫자로 변환해서 활용하도록 했습니다.
- 리팩터링: 거래내역 repository 의 compareMoneyAndAmount 메소드를 서비스로 이전했습니다.


resolves: #10, #11