### PR TITLE
fix: transaction get

### DIFF
--- a/src/transaction/transaction.interface.ts
+++ b/src/transaction/transaction.interface.ts
@@ -1,7 +1,7 @@
 import { User } from '../users/entities/user.entity';
 
 export interface ListQueryOptions {
-  account_id: string;
+  acc_num: string;
   page: string;
   trans_type?: 'in' | 'out';
   startDate?: string;

--- a/src/transaction/transaction.repository.ts
+++ b/src/transaction/transaction.repository.ts
@@ -40,7 +40,7 @@ export class TransactionRepository extends Repository<Transaction> {
     trans_type,
     startDate,
     endDate,
-    account_id,
+    acc_num,
   }: ListWithPageAndUserOptions): Promise<Transaction[]> {
     // * 거래일시에 대한 필터링을 수행합니다. 처음과 끝 날짜를 계산하여 문자열 형식으로 반환합니다.
     const [startDateString, endDateString] = this.getDatePeriod(
@@ -60,7 +60,7 @@ export class TransactionRepository extends Repository<Transaction> {
     }
     const transaction = await this.createQueryBuilder('transaction')
       .leftJoinAndSelect('transaction.account', 'account')
-      .where('account.id = :account_id', { account_id })
+      .where('account.acc_num = :acc_num', { acc_num })
       .andWhere('transaction.createdAt >= :startDate', {
         startDate: startDateString,
       })

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -29,7 +29,8 @@ export class TransactionService {
     query: ListWithPageAndUserOptions,
   ): Promise<Transaction[]> {
     // * 계좌의 소유주인지 여부를 확인합니다.
-    const account = await this.accountRepository.findOne(+query.account_id, {
+    const account = await this.accountRepository.findOne({
+      where: { acc_num: query.acc_num },
       join: {
         alias: 'account',
         leftJoinAndSelect: { user: 'account.user' },


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트

## 작업 개요
- 거래내역 조회 API의 쿼리 파라미터를 계좌 번호로 변경

## 상세 내용
- 해당 API의 쿼리 파라미터를 account id에서 계좌 번호(acc_num)로 변경
- 이는 입금, 출금 API의 쿼리 파라미터로 계좌 번호가 사용되는 것에 통일하기 위함임

resolves: #62 